### PR TITLE
Fix - #4 - Create dir if it doesn't exist on file log

### DIFF
--- a/include/Logger.h
+++ b/include/Logger.h
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <memory>
 #include <iomanip>
+#include <filesystem>
 #if defined(__linux__) || defined(linux) || defined(__GNUG__)
     #include <cxxabi.h>
 #endif
@@ -126,6 +127,13 @@ namespace Xale::Logger
 			LoggerConfig::logFile.close();
         else
         {
+          auto pos = filePath.rfind("/");
+          if (pos != std::string::npos) 
+          {
+            std::filesystem::path fsPath = filePath.substr(0, pos);
+            if (!std::filesystem::exists(fsPath)) 
+              std::filesystem::create_directories(fsPath);
+          }
 			LoggerConfig::logFile.open(filePath, std::ios::app);
         }
     }

--- a/include/Logger.h
+++ b/include/Logger.h
@@ -127,13 +127,13 @@ namespace Xale::Logger
 			LoggerConfig::logFile.close();
         else
         {
-          auto pos = filePath.rfind("/");
-          if (pos != std::string::npos) 
-          {
-            std::filesystem::path fsPath = filePath.substr(0, pos);
-            if (!std::filesystem::exists(fsPath)) 
-              std::filesystem::create_directories(fsPath);
-          }
+            auto pos = filePath.rfind("/");
+            if (pos != std::string::npos) 
+            {
+                std::filesystem::path fsPath = filePath.substr(0, pos);
+                if (!std::filesystem::exists(fsPath)) 
+                    std::filesystem::create_directories(fsPath);
+            }
 			LoggerConfig::logFile.open(filePath, std::ios::app);
         }
     }


### PR DESCRIPTION
close: #4 

**Context:**

Logging into a non-existing file path was resulting in an early crash.  
The chosen solution in the linked issue is to create the directories directly from the Logger to avoid this.

**Solution:**

The solution I came up with is to use the standard C++ filesystem library.

What is done is to strip the last block of the defined path; this allows us to obtain a relative path representing the directory tree where the log file will be located.  
To do so, we create a `pos` variable to get the position of the last `/` character.  
Then, we use `std::string::npos` to check whether `pos` actually contains a valid position. This ensures that the given path is correct. We also use this check to avoid creating a directory when the path refers to a simple file (e.g. `file.log`).

Finally, we create the directory tree using the `create_directories` function.

**Limitations:**

This solution is highly Unix-dependent and may need improvements to ensure it works properly on Windows environments (e.g. handling the `\\` Windows path syntax).

There is currently no automated test for this change. Since testing this would require creating a complete directory tree, it is not covered by the project's `tests` folder. If you have any ideas on how to implement such tests, feel free to share them.

I am not sure whether this project is open to PRs, but I found it quite interesting and decided to dive into it. Feel free to review this or not — no hard feelings.

Thanks in advance!
